### PR TITLE
Add Liquity protocol

### DIFF
--- a/contracts/flusher/balances.sol
+++ b/contracts/flusher/balances.sol
@@ -28,7 +28,7 @@ contract Resolver {
             tokensBal[i] = Balances({
                 flusher: flushers[i],
                 balance: bals,
-                isDeployed: isContractDeployed(flushers[i]);
+                isDeployed: isContractDeployed(flushers[i])
             });
         }
         return tokensBal;

--- a/contracts/protocols/mainnet/liquity.sol
+++ b/contracts/protocols/mainnet/liquity.sol
@@ -30,13 +30,53 @@ interface PoolLike {
   function getETH() external view returns (uint);
 }
 
-contract DSMath {
+interface HintHelpersLike {
+  function computeNominalCR(uint _coll, uint _debt) external pure returns (uint);
+  function computeCR(uint _coll, uint _debt, uint _price) external pure returns (uint);
+  function getApproxHint(uint _CR, uint _numTrials, uint _inputRandomSeed) external view returns (
+    address hintAddress,
+    uint diff,
+    uint latestRandomSeed
+  );
+  function getRedemptionHints(uint _LUSDamount, uint _price, uint _maxIterations) external view returns (
+    address firstHint,
+    uint partialRedemptionHintNICR,
+    uint truncatedLUSDamount
+  );
+}
+
+interface SortedTrovesLike {
+  function getSize() external view returns (uint256);
+  function findInsertPosition(uint256 _ICR, address _prevId, address _nextId) external view returns (address, address);
+}
+
+contract Math {
+  /* DSMath add */
   function add(uint x, uint y) internal pure returns (uint z) {
     require((z = x + y) >= x, "math-not-safe");
   }
+  
+  /* DSMath mul */
+  function mul(uint x, uint y) internal pure returns (uint z) {
+        require(y == 0 || (z = x * y) / y == x, "math-not-safe");
+    }
+
+  /* Uniswap V2 sqrt */
+  function sqrt(uint y) internal pure returns (uint z) {
+    if (y > 3) {
+      z = y;
+      uint x = y / 2 + 1;
+      while (x < z) {
+        z = x;
+        x = (y / x + x) / 2;
+      }
+    } else if (y != 0) {
+      z = 1;
+      }
+    }
 }
 
-contract Helpers is DSMath {
+contract Helpers is Math {
   TroveManagerLike internal constant troveManager =
     TroveManagerLike(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
 
@@ -52,6 +92,12 @@ contract Helpers is DSMath {
   PoolLike internal constant defaultPool =
     PoolLike(0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C);
 
+  HintHelpersLike internal constant hintHelpers =
+    HintHelpersLike(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
+  
+  SortedTrovesLike internal constant sortedTroves =
+    SortedTrovesLike(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
+  
   struct Trove {
     uint collateral;
     uint debt;
@@ -119,6 +165,30 @@ contract Resolver is Helpers {
     uint tcr = troveManager.getTCR(oracleEthPrice);
     bool isInRecoveryMode = troveManager.checkRecoveryMode(oracleEthPrice);
     return System(borrowFee, ethTvl, tcr, isInRecoveryMode);
+  }
+
+  function getTrovePositionHints(uint collateral, uint debt, uint searchIterations) external view returns (
+    address upperHint,
+    address lowerHint
+  ) {
+    // See: https://github.com/liquity/dev#supplying-hints-to-trove-operations
+    uint nominalCr = hintHelpers.computeNominalCR(collateral, debt);
+    searchIterations = searchIterations == 0 ? mul(10, sqrt(sortedTroves.getSize())) : searchIterations;
+    (address hintAddress, ,) = hintHelpers.getApproxHint(nominalCr, searchIterations, 3);
+    return sortedTroves.findInsertPosition(nominalCr, hintAddress, hintAddress);
+  }
+
+  function getRedemptionPositionHints(uint amount, uint oracleEthPrice, uint searchIterations) external view returns (
+    uint partialHintNicr,
+    address firstHint,
+    address upperHint,
+    address lowerHint
+  ) {
+    // See: https://github.com/liquity/dev#hints-for-redeemcollateral
+    (firstHint, partialHintNicr, ) = hintHelpers.getRedemptionHints(amount, oracleEthPrice, 0);
+    searchIterations = searchIterations == 0 ? mul(10, sqrt(sortedTroves.getSize())) : searchIterations;
+    (address hintAddress, ,) = hintHelpers.getApproxHint(partialHintNicr, searchIterations, 3);
+    (upperHint, lowerHint) = sortedTroves.findInsertPosition(partialHintNicr, hintAddress, hintAddress);
   }
 }
 

--- a/contracts/protocols/mainnet/liquity.sol
+++ b/contracts/protocols/mainnet/liquity.sol
@@ -1,0 +1,101 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+interface TroveManagerLike {
+  function getCurrentICR(address _borrower, uint _price) external view returns (uint);
+  function getEntireDebtAndColl(address _borrower) external view returns (
+    uint debt, 
+    uint coll, 
+    uint pendingLUSDDebtReward, 
+    uint pendingETHReward
+  );
+}
+
+interface StabilityPoolLike {
+  function getCompoundedLUSDDeposit(address _depositor) external view returns (uint);
+  function getDepositorETHGain(address _depositor) external view returns (uint);
+  function getDepositorLQTYGain(address _depositor) external view returns (uint);
+}
+
+abstract contract StakingLike {
+  mapping(address => uint) public stakes;
+  function getPendingETHGain(address _user) external virtual view returns (uint);
+  function getPendingLUSDGain(address _user) external virtual view returns (uint);
+}
+
+abstract contract PriceFeedLike {
+  uint public lastGoodPrice;
+}
+
+contract Helpers {
+  TroveManagerLike internal constant troveManager =
+    TroveManagerLike(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
+
+  StabilityPoolLike internal constant stabilityPool = 
+    StabilityPoolLike(0x66017D22b0f8556afDd19FC67041899Eb65a21bb);
+
+  StakingLike internal constant staking =
+    StakingLike(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d);
+
+  PriceFeedLike internal constant priceFeed = 
+    PriceFeedLike(0x4c517D4e2C851CA76d7eC94B805269Df0f2201De);
+  
+  struct Trove {
+    uint collateral;
+    uint debt;
+    uint icr;
+  }
+
+  struct StabilityDeposit {
+    uint deposit;
+    uint ethGain;
+    uint lqtyGain;
+  }
+
+  struct Stake {
+    uint amount;
+    uint ethGain;
+    uint lusdGain;
+  }
+
+  struct Position {
+    Trove trove;
+    StabilityDeposit stability;
+    Stake stake;
+  }
+}
+
+
+contract Resolver is Helpers {
+  function getTrove(address owner) public view returns (Trove memory) {
+    (uint debt, uint collateral, uint _, uint __) = troveManager.getEntireDebtAndColl(owner);
+    uint price = priceFeed.lastGoodPrice();
+    uint icr = troveManager.getCurrentICR(owner, price);
+    return Trove(collateral, debt, icr);
+  }
+
+  function getStabilityDeposit(address owner) public view returns (StabilityDeposit memory) {
+    uint deposit = stabilityPool.getCompoundedLUSDDeposit(owner);
+    uint ethGain = stabilityPool.getDepositorETHGain(owner);
+    uint lqtyGain = stabilityPool.getDepositorLQTYGain(owner);
+    return StabilityDeposit(deposit, ethGain, lqtyGain);
+  }
+
+  function getStake(address owner) public view returns (Stake memory) {
+    uint amount = staking.stakes(owner);
+    uint ethGain = staking.getPendingETHGain(owner);
+    uint lusdGain = staking.getPendingLUSDGain(owner);
+    return Stake(amount, ethGain, lusdGain);
+  }
+
+  function getPosition(address owner) external view returns (Position memory) {
+    Trove memory trove = getTrove(owner);
+    StabilityDeposit memory stability = getStabilityDeposit(owner);
+    Stake memory stake = getStake(owner);
+    return Position(trove, stability, stake);
+  }
+}
+
+contract InstaLiquityResolver is Resolver {
+  string public constant name = "Liquity-Resolver-v1";
+}

--- a/contracts/protocols/mainnet/liquity.sol
+++ b/contracts/protocols/mainnet/liquity.sol
@@ -2,196 +2,198 @@ pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 interface TroveManagerLike {
-  function getBorrowingRateWithDecay() external view returns (uint);
-  function getTCR(uint _price) external view returns (uint);
-  function getCurrentICR(address _borrower, uint _price) external view returns (uint);
-  function checkRecoveryMode(uint _price) external view returns (bool);
-  function getEntireDebtAndColl(address _borrower) external view returns (
-    uint debt, 
-    uint coll, 
-    uint pendingLUSDDebtReward, 
-    uint pendingETHReward
-  );
+    function getBorrowingRateWithDecay() external view returns (uint);
+    function getTCR(uint _price) external view returns (uint);
+    function getCurrentICR(address _borrower, uint _price) external view returns (uint);
+    function checkRecoveryMode(uint _price) external view returns (bool);
+    function getEntireDebtAndColl(address _borrower) external view returns (
+        uint debt, 
+        uint coll, 
+        uint pendingLUSDDebtReward, 
+        uint pendingETHReward
+    );
 }
 
 interface StabilityPoolLike {
-  function getCompoundedLUSDDeposit(address _depositor) external view returns (uint);
-  function getDepositorETHGain(address _depositor) external view returns (uint);
-  function getDepositorLQTYGain(address _depositor) external view returns (uint);
+    function getCompoundedLUSDDeposit(address _depositor) external view returns (uint);
+    function getDepositorETHGain(address _depositor) external view returns (uint);
+    function getDepositorLQTYGain(address _depositor) external view returns (uint);
 }
 
 interface StakingLike {
-  function stakes(address owner) external view returns (uint);
-  function getPendingETHGain(address _user) external view returns (uint);
-  function getPendingLUSDGain(address _user) external view returns (uint);
+    function stakes(address owner) external view returns (uint);
+    function getPendingETHGain(address _user) external view returns (uint);
+    function getPendingLUSDGain(address _user) external view returns (uint);
 }
 
 interface PoolLike {
-  function getETH() external view returns (uint);
+    function getETH() external view returns (uint);
 }
 
 interface HintHelpersLike {
-  function computeNominalCR(uint _coll, uint _debt) external pure returns (uint);
-  function computeCR(uint _coll, uint _debt, uint _price) external pure returns (uint);
-  function getApproxHint(uint _CR, uint _numTrials, uint _inputRandomSeed) external view returns (
-    address hintAddress,
-    uint diff,
-    uint latestRandomSeed
-  );
-  function getRedemptionHints(uint _LUSDamount, uint _price, uint _maxIterations) external view returns (
-    address firstHint,
-    uint partialRedemptionHintNICR,
-    uint truncatedLUSDamount
-  );
+    function computeNominalCR(uint _coll, uint _debt) external pure returns (uint);
+    function computeCR(uint _coll, uint _debt, uint _price) external pure returns (uint);
+    function getApproxHint(uint _CR, uint _numTrials, uint _inputRandomSeed) external view returns (
+        address hintAddress,
+        uint diff,
+        uint latestRandomSeed
+    );
+    function getRedemptionHints(uint _LUSDamount, uint _price, uint _maxIterations) external view returns (
+        address firstHint,
+        uint partialRedemptionHintNICR,
+        uint truncatedLUSDamount
+    );
 }
 
 interface SortedTrovesLike {
-  function getSize() external view returns (uint256);
-  function findInsertPosition(uint256 _ICR, address _prevId, address _nextId) external view returns (address, address);
+    function getSize() external view returns (uint256);
+    function findInsertPosition(uint256 _ICR, address _prevId, address _nextId) external view returns (address, address);
 }
 
 contract Math {
-  /* DSMath add */
-  function add(uint x, uint y) internal pure returns (uint z) {
-    require((z = x + y) >= x, "math-not-safe");
-  }
-  
-  /* DSMath mul */
-  function mul(uint x, uint y) internal pure returns (uint z) {
-        require(y == 0 || (z = x * y) / y == x, "math-not-safe");
+    /* DSMath add */
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x, "math-not-safe");
     }
+    
+    /* DSMath mul */
+    function mul(uint x, uint y) internal pure returns (uint z) {
+                require(y == 0 || (z = x * y) / y == x, "math-not-safe");
+        }
 
-  /* Uniswap V2 sqrt */
-  function sqrt(uint y) internal pure returns (uint z) {
-    if (y > 3) {
-      z = y;
-      uint x = y / 2 + 1;
-      while (x < z) {
-        z = x;
-        x = (y / x + x) / 2;
-      }
-    } else if (y != 0) {
-      z = 1;
-      }
-    }
+    /* Uniswap V2 sqrt */
+    function sqrt(uint y) internal pure returns (uint z) {
+        if (y > 3) {
+            z = y;
+            uint x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+            }
+        }
 }
 
 contract Helpers is Math {
-  TroveManagerLike internal constant troveManager =
-    TroveManagerLike(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
+    TroveManagerLike internal constant troveManager =
+        TroveManagerLike(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
 
-  StabilityPoolLike internal constant stabilityPool = 
-    StabilityPoolLike(0x66017D22b0f8556afDd19FC67041899Eb65a21bb);
+    StabilityPoolLike internal constant stabilityPool = 
+        StabilityPoolLike(0x66017D22b0f8556afDd19FC67041899Eb65a21bb);
 
-  StakingLike internal constant staking =
-    StakingLike(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d);
+    StakingLike internal constant staking =
+        StakingLike(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d);
 
-  PoolLike internal constant activePool =
-    PoolLike(0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F);
-  
-  PoolLike internal constant defaultPool =
-    PoolLike(0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C);
+    PoolLike internal constant activePool =
+        PoolLike(0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F);
+    
+    PoolLike internal constant defaultPool =
+        PoolLike(0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C);
 
-  HintHelpersLike internal constant hintHelpers =
-    HintHelpersLike(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
-  
-  SortedTrovesLike internal constant sortedTroves =
-    SortedTrovesLike(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
-  
-  struct Trove {
-    uint collateral;
-    uint debt;
-    uint icr;
-  }
+    HintHelpersLike internal constant hintHelpers =
+        HintHelpersLike(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
+    
+    SortedTrovesLike internal constant sortedTroves =
+        SortedTrovesLike(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
+    
+    struct Trove {
+        uint collateral;
+        uint debt;
+        uint icr;
+    }
 
-  struct StabilityDeposit {
-    uint deposit;
-    uint ethGain;
-    uint lqtyGain;
-  }
+    struct StabilityDeposit {
+        uint deposit;
+        uint ethGain;
+        uint lqtyGain;
+    }
 
-  struct Stake {
-    uint amount;
-    uint ethGain;
-    uint lusdGain;
-  }
+    struct Stake {
+        uint amount;
+        uint ethGain;
+        uint lusdGain;
+    }
 
-  struct Position {
-    Trove trove;
-    StabilityDeposit stability;
-    Stake stake;
-  }
+    struct Position {
+        Trove trove;
+        StabilityDeposit stability;
+        Stake stake;
+    }
 
-  struct System {
-    uint borrowFee;
-    uint ethTvl;
-    uint tcr;
-    bool isInRecoveryMode;
-  }
+    struct System {
+        uint borrowFee;
+        uint ethTvl;
+        uint tcr;
+        bool isInRecoveryMode;
+    }
 }
 
 
 contract Resolver is Helpers {
-  function getTrove(address owner, uint oracleEthPrice) public view returns (Trove memory) {
-    (uint debt, uint collateral, , ) = troveManager.getEntireDebtAndColl(owner);
-    uint icr = troveManager.getCurrentICR(owner, oracleEthPrice);
-    return Trove(collateral, debt, icr);
-  }
+    function getTrove(address owner, uint oracleEthPrice) public view returns (Trove memory) {
+        (uint debt, uint collateral, , ) = troveManager.getEntireDebtAndColl(owner);
+        uint icr = troveManager.getCurrentICR(owner, oracleEthPrice);
+        return Trove(collateral, debt, icr);
+    }
 
-  function getStabilityDeposit(address owner) public view returns (StabilityDeposit memory) {
-    uint deposit = stabilityPool.getCompoundedLUSDDeposit(owner);
-    uint ethGain = stabilityPool.getDepositorETHGain(owner);
-    uint lqtyGain = stabilityPool.getDepositorLQTYGain(owner);
-    return StabilityDeposit(deposit, ethGain, lqtyGain);
-  }
+    function getStabilityDeposit(address owner) public view returns (StabilityDeposit memory) {
+        uint deposit = stabilityPool.getCompoundedLUSDDeposit(owner);
+        uint ethGain = stabilityPool.getDepositorETHGain(owner);
+        uint lqtyGain = stabilityPool.getDepositorLQTYGain(owner);
+        return StabilityDeposit(deposit, ethGain, lqtyGain);
+    }
 
-  function getStake(address owner) public view returns (Stake memory) {
-    uint amount = staking.stakes(owner);
-    uint ethGain = staking.getPendingETHGain(owner);
-    uint lusdGain = staking.getPendingLUSDGain(owner);
-    return Stake(amount, ethGain, lusdGain);
-  }
+    function getStake(address owner) public view returns (Stake memory) {
+        uint amount = staking.stakes(owner);
+        uint ethGain = staking.getPendingETHGain(owner);
+        uint lusdGain = staking.getPendingLUSDGain(owner);
+        return Stake(amount, ethGain, lusdGain);
+    }
 
-  function getPosition(address owner, uint oracleEthPrice) external view returns (Position memory) {
-    Trove memory trove = getTrove(owner, oracleEthPrice);
-    StabilityDeposit memory stability = getStabilityDeposit(owner);
-    Stake memory stake = getStake(owner);
-    return Position(trove, stability, stake);
-  }
+    function getPosition(address owner, uint oracleEthPrice) external view returns (Position memory) {
+        Trove memory trove = getTrove(owner, oracleEthPrice);
+        StabilityDeposit memory stability = getStabilityDeposit(owner);
+        Stake memory stake = getStake(owner);
+        return Position(trove, stability, stake);
+    }
 
-  function getSystemState(uint oracleEthPrice) external view returns (System memory) {
-    uint borrowFee = troveManager.getBorrowingRateWithDecay();
-    uint ethTvl = add(activePool.getETH(), defaultPool.getETH());
-    uint tcr = troveManager.getTCR(oracleEthPrice);
-    bool isInRecoveryMode = troveManager.checkRecoveryMode(oracleEthPrice);
-    return System(borrowFee, ethTvl, tcr, isInRecoveryMode);
-  }
+    function getSystemState(uint oracleEthPrice) external view returns (System memory) {
+        uint borrowFee = troveManager.getBorrowingRateWithDecay();
+        uint ethTvl = add(activePool.getETH(), defaultPool.getETH());
+        uint tcr = troveManager.getTCR(oracleEthPrice);
+        bool isInRecoveryMode = troveManager.checkRecoveryMode(oracleEthPrice);
+        return System(borrowFee, ethTvl, tcr, isInRecoveryMode);
+    }
 
-  function getTrovePositionHints(uint collateral, uint debt, uint searchIterations) external view returns (
-    address upperHint,
-    address lowerHint
-  ) {
-    // See: https://github.com/liquity/dev#supplying-hints-to-trove-operations
-    uint nominalCr = hintHelpers.computeNominalCR(collateral, debt);
-    searchIterations = searchIterations == 0 ? mul(10, sqrt(sortedTroves.getSize())) : searchIterations;
-    (address hintAddress, ,) = hintHelpers.getApproxHint(nominalCr, searchIterations, 3);
-    return sortedTroves.findInsertPosition(nominalCr, hintAddress, hintAddress);
-  }
+    function getTrovePositionHints(uint collateral, uint debt, uint searchIterations, uint randomSeed) external view returns (
+        address upperHint,
+        address lowerHint
+    ) {
+        // See: https://github.com/liquity/dev#supplying-hints-to-trove-operations
+        uint nominalCr = hintHelpers.computeNominalCR(collateral, debt);
+        searchIterations = searchIterations == 0 ? mul(10, sqrt(sortedTroves.getSize())) : searchIterations;
+        randomSeed = randomSeed == 0 ? block.number : randomSeed;
+        (address hintAddress, ,) = hintHelpers.getApproxHint(nominalCr, searchIterations, randomSeed);
+        return sortedTroves.findInsertPosition(nominalCr, hintAddress, hintAddress);
+    }
 
-  function getRedemptionPositionHints(uint amount, uint oracleEthPrice, uint searchIterations) external view returns (
-    uint partialHintNicr,
-    address firstHint,
-    address upperHint,
-    address lowerHint
-  ) {
-    // See: https://github.com/liquity/dev#hints-for-redeemcollateral
-    (firstHint, partialHintNicr, ) = hintHelpers.getRedemptionHints(amount, oracleEthPrice, 0);
-    searchIterations = searchIterations == 0 ? mul(10, sqrt(sortedTroves.getSize())) : searchIterations;
-    (address hintAddress, ,) = hintHelpers.getApproxHint(partialHintNicr, searchIterations, 3);
-    (upperHint, lowerHint) = sortedTroves.findInsertPosition(partialHintNicr, hintAddress, hintAddress);
-  }
+    function getRedemptionPositionHints(uint amount, uint oracleEthPrice, uint searchIterations, uint randomSeed) external view returns (
+        uint partialHintNicr,
+        address firstHint,
+        address upperHint,
+        address lowerHint
+    ) {
+        // See: https://github.com/liquity/dev#hints-for-redeemcollateral
+        (firstHint, partialHintNicr, ) = hintHelpers.getRedemptionHints(amount, oracleEthPrice, 0);
+        searchIterations = searchIterations == 0 ? mul(10, sqrt(sortedTroves.getSize())) : searchIterations;
+        randomSeed = randomSeed == 0 ? block.number : randomSeed;
+        (address hintAddress, ,) = hintHelpers.getApproxHint(partialHintNicr, searchIterations, randomSeed);
+        (upperHint, lowerHint) = sortedTroves.findInsertPosition(partialHintNicr, hintAddress, hintAddress);
+    }
 }
 
 contract InstaLiquityResolver is Resolver {
-  string public constant name = "Liquity-Resolver-v1";
+    string public constant name = "Liquity-Resolver-v1";
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The smart contracts which simplifies read operations.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test"
   },
   "repository": {
     "type": "git",

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -1,0 +1,95 @@
+const { expect } = require("chai");
+const hardhatConfig = require("../hardhat.config");
+const { BigNumber } = hre.ethers;
+
+// Deterministic block number to run these tests from on forked mainnet. If you change this, tests will break.
+const BLOCK_NUMBER = 12478959;
+
+// Liquity user with a Trove, Stability deposit, and Stake
+const JUSTIN_SUN_ADDRESS = "0x903d12bf2c57a29f32365917c706ce0e1a84cce3";
+
+/* Begin: Mock test data (based on specified BLOCK_NUMBER and JUSTIN_SUN_ADDRESS) */
+const expectedTrovePosition = [
+  /* collateral */ BigNumber.from("582880000000000000000000"),
+  /* debt */ BigNumber.from("372000200000000000000000000"),
+  /* icr */ BigNumber.from("3839454035181671407"),
+];
+const expectedStabilityPosition = [
+  /* deposit */ BigNumber.from("299979329615565997640451998"),
+  /* ethGain */ BigNumber.from("8629038660000000000"),
+  /* lqtyGain */ BigNumber.from("53244322633874479119945"),
+];
+const expectedStakePosition = [
+  /* amount */ BigNumber.from("981562996504090969804965"),
+  /* ethGain */ BigNumber.from("18910541408996344243"),
+  /* lusdGain */ BigNumber.from("66201062534511228032281"),
+];
+/* End: Mock test data */
+
+describe("InstaLiquityResolver", () => {
+  let liquity;
+
+  before(async () => {
+    await resetHardhatBlockNumber(BLOCK_NUMBER); // Start tests from clean mainnet fork at BLOCK_NUMBER
+
+    const LiquityFactory = await hre.ethers.getContractFactory(
+      "InstaLiquityResolver"
+    );
+
+    liquity = await LiquityFactory.deploy();
+    await liquity.deployed();
+  });
+
+  it("deploys the resolver", () => {
+    expect(liquity.address).to.exist;
+  });
+
+  describe("getTrove()", () => {
+    it("returns a user's Trove position", async () => {
+      const trovePosition = await liquity.getTrove(JUSTIN_SUN_ADDRESS);
+      expect(trovePosition).to.eql(expectedTrovePosition);
+    });
+  });
+
+  describe("getStabilityDeposit()", () => {
+    it("returns a user's Stability Pool position", async () => {
+      const stabilityPosition = await liquity.getStabilityDeposit(
+        JUSTIN_SUN_ADDRESS
+      );
+      expect(stabilityPosition).to.eql(expectedStabilityPosition);
+    });
+  });
+
+  describe("getStake()", () => {
+    it("returns a user's Stake position", async () => {
+      const stakePosition = await liquity.getStake(JUSTIN_SUN_ADDRESS);
+      expect(stakePosition).to.eql(expectedStakePosition);
+    });
+  });
+
+  describe("getPosition()", () => {
+    it("returns a user's Liquity position", async () => {
+      const position = await liquity.getPosition(JUSTIN_SUN_ADDRESS);
+      const expectedPosition = [
+        expectedTrovePosition,
+        expectedStabilityPosition,
+        expectedStakePosition,
+      ];
+      expect(position).to.eql(expectedPosition);
+    });
+  });
+});
+
+const resetHardhatBlockNumber = async (blockNumber) => {
+  return await hre.network.provider.request({
+    method: "hardhat_reset",
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: hardhatConfig.networks.hardhat.forking.url,
+          blockNumber,
+        },
+      },
+    ],
+  });
+};

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -112,6 +112,45 @@ describe("InstaLiquityResolver", () => {
       expect(systemState).to.eql(expectedSystemState);
     });
   });
+
+  describe("getTrovePositionHints()", () => {
+    it("returns the upper and lower address of Troves nearest to the given Trove", async () => {
+      const collateral = hre.ethers.utils.parseEther("10");
+      const debt = hre.ethers.utils.parseUnits("5000", 18);
+      const searchIterations = 10;
+      const [upperHint, lowerHint] = await liquity.getTrovePositionHints(
+        collateral,
+        debt,
+        searchIterations
+      );
+
+      expect(upperHint).eq("0xbf9a4eCC4151f28C03100bA2C0555a3D3e439e69");
+      expect(lowerHint).eq("0xa4FC81A7AB93360543eb1e814D0127f466012CED");
+    });
+  });
+
+  describe("getRedemptionPositionHints()", () => {
+    it("returns the upper and lower address of the range of Troves to be redeemed against the given amount", async () => {
+      const amount = hre.ethers.utils.parseUnits("10000", 18); // 10,000 LUSD
+      const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
+      const searchIterations = 10;
+      const [
+        partialRedemptionHintNicr,
+        firstHint,
+        upperHint,
+        lowerHint,
+      ] = await liquity.getRedemptionPositionHints(
+        amount,
+        oracleEthPrice,
+        searchIterations
+      );
+
+      expect(partialRedemptionHintNicr).eq("69529933762909647");
+      expect(firstHint).eq("0xc16aDd8bA17ab81B27e930Da8a67848120565d8c");
+      expect(upperHint).eq("0x66882C005188F0F4d95825ED7A7F78ed3055f167");
+      expect(lowerHint).eq("0x0C22C11a8ed4C23ffD19629283548B1692b58e92");
+    });
+  });
 });
 
 const resetHardhatBlockNumber = async (blockNumber) => {

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -18,6 +18,7 @@ const expectedTrovePosition = {
   collateral: BigNumber.from("582880000000000000000000"),
   debt: BigNumber.from("372000200000000000000000000"),
   icr: BigNumber.from("3859882210893925325"),
+  oracleEthPrice: BigNumber.from("2463417777980000000000"),
 };
 const expectedStabilityPosition = {
   deposit: BigNumber.from("299979329615565997640451998"),
@@ -34,6 +35,7 @@ const expectedSystemState = {
   ethTvl: BigNumber.from("852500462432421494350957"),
   tcr: BigNumber.from("3250195441371082828"),
   isInRecoveryMode: false,
+  oracleEthPrice: BigNumber.from("2463417777980000000000"),
 };
 const expectedTrovePositionHints = {
   upperHint: "0xbf9a4eCC4151f28C03100bA2C0555a3D3e439e69",
@@ -44,6 +46,7 @@ const expectedRedemptionPositionHints = {
   firstHint: "0xc16aDd8bA17ab81B27e930Da8a67848120565d8c",
   upperHint: "0x66882C005188F0F4d95825ED7A7F78ed3055f167",
   lowerHint: "0x0C22C11a8ed4C23ffD19629283548B1692b58e92",
+  oracleEthPrice: BigNumber.from("2463417777980000000000"),
 };
 /* End: Mock test data */
 
@@ -75,22 +78,23 @@ describe("InstaLiquityResolver", () => {
 
   describe("getTrove()", () => {
     it("returns a user's Trove position", async () => {
-      const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
-      const trovePosition = await liquity.getTrove(
-        JUSTIN_SUN_ADDRESS,
-        oracleEthPrice
+      const trovePosition = await liquity.callStatic.getTrove(
+        JUSTIN_SUN_ADDRESS
       );
       expect(trovePosition.collateral).to.equal(
         expectedTrovePosition.collateral
       );
       expect(trovePosition.debt).to.equal(expectedTrovePosition.debt);
       expect(trovePosition.icr).to.equal(expectedTrovePosition.icr);
+      expect(trovePosition.oracleEthPrice).to.equal(
+        expectedTrovePosition.oracleEthPrice
+      );
     });
   });
 
   describe("getStabilityDeposit()", () => {
     it("returns a user's Stability Pool position", async () => {
-      const stabilityPosition = await liquity.getStabilityDeposit(
+      const stabilityPosition = await liquity.callStatic.getStabilityDeposit(
         JUSTIN_SUN_ADDRESS
       );
       expect(stabilityPosition.deposit).to.equal(
@@ -107,7 +111,9 @@ describe("InstaLiquityResolver", () => {
 
   describe("getStake()", () => {
     it("returns a user's Stake position", async () => {
-      const stakePosition = await liquity.getStake(JUSTIN_SUN_ADDRESS);
+      const stakePosition = await liquity.callStatic.getStake(
+        JUSTIN_SUN_ADDRESS
+      );
       expect(stakePosition.amount).to.equal(expectedStakePosition.amount);
       expect(stakePosition.ethGain).to.equal(expectedStakePosition.ethGain);
       expect(stakePosition.lusdGain).to.equal(expectedStakePosition.lusdGain);
@@ -116,11 +122,7 @@ describe("InstaLiquityResolver", () => {
 
   describe("getPosition()", () => {
     it("returns a user's Liquity position", async () => {
-      const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
-      const position = await liquity.getPosition(
-        JUSTIN_SUN_ADDRESS,
-        oracleEthPrice
-      );
+      const position = await liquity.callStatic.getPosition(JUSTIN_SUN_ADDRESS);
       const expectedPosition = {
         trove: expectedTrovePosition,
         stability: expectedStabilityPosition,
@@ -150,13 +152,15 @@ describe("InstaLiquityResolver", () => {
 
   describe("getSystemState()", () => {
     it("returns Liquity system state", async () => {
-      const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
-      const systemState = await liquity.getSystemState(oracleEthPrice);
+      const systemState = await liquity.callStatic.getSystemState();
       expect(systemState.borrowFee).to.equal(expectedSystemState.borrowFee);
       expect(systemState.ethTvl).to.equal(expectedSystemState.ethTvl);
       expect(systemState.tcr).to.equal(expectedSystemState.tcr);
       expect(systemState.isInRecoveryMode).to.equal(
         expectedSystemState.isInRecoveryMode
+      );
+      expect(systemState.oracleEthPrice).to.equal(
+        expectedSystemState.oracleEthPrice
       );
     });
   });
@@ -167,7 +171,10 @@ describe("InstaLiquityResolver", () => {
       const debt = hre.ethers.utils.parseUnits("5000", 18); // 5,000 LUSD
       const searchIterations = 10;
       const randomSeed = 3;
-      const [upperHint, lowerHint] = await liquity.getTrovePositionHints(
+      const [
+        upperHint,
+        lowerHint,
+      ] = await liquity.callStatic.getTrovePositionHints(
         collateral,
         debt,
         searchIterations,
@@ -182,7 +189,6 @@ describe("InstaLiquityResolver", () => {
   describe("getRedemptionPositionHints()", () => {
     it("returns the upper and lower address of the range of Troves to be redeemed against the given amount", async () => {
       const amount = hre.ethers.utils.parseUnits("10000", 18); // 10,000 LUSD
-      const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
       const searchIterations = 10;
       const randomSeed = 3;
       const [
@@ -190,9 +196,9 @@ describe("InstaLiquityResolver", () => {
         firstHint,
         upperHint,
         lowerHint,
-      ] = await liquity.getRedemptionPositionHints(
-        amount,
         oracleEthPrice,
+      ] = await liquity.callStatic.getRedemptionPositionHints(
+        amount,
         searchIterations,
         randomSeed
       );
@@ -203,6 +209,7 @@ describe("InstaLiquityResolver", () => {
       expect(firstHint).eq(expectedRedemptionPositionHints.firstHint);
       expect(upperHint).eq(expectedRedemptionPositionHints.upperHint);
       expect(lowerHint).eq(expectedRedemptionPositionHints.lowerHint);
+      expect(oracleEthPrice).eq(expectedRedemptionPositionHints.oracleEthPrice);
     });
   });
 });

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const hardhatConfig = require("../hardhat.config");
+
 const { BigNumber } = hre.ethers;
 
 // Deterministic block number to run these tests from on forked mainnet. If you change this, tests will break.
@@ -13,28 +14,37 @@ const PRICE_FEED_ADDRESS = "0x4c517D4e2C851CA76d7eC94B805269Df0f2201De";
 const PRICE_FEED_ABI = ["function fetchPrice() external returns (uint)"];
 
 /* Begin: Mock test data (based on specified BLOCK_NUMBER and JUSTIN_SUN_ADDRESS) */
-const expectedTrovePosition = [
-  /* collateral */ BigNumber.from("582880000000000000000000"),
-  /* debt */ BigNumber.from("372000200000000000000000000"),
-  /* icr */ BigNumber.from("3859882210893925325"),
-];
-const expectedStabilityPosition = [
-  /* deposit */ BigNumber.from("299979329615565997640451998"),
-  /* ethGain */ BigNumber.from("8629038660000000000"),
-  /* lqtyGain */ BigNumber.from("53244322633874479119945"),
-];
-const expectedStakePosition = [
-  /* amount */ BigNumber.from("981562996504090969804965"),
-  /* ethGain */ BigNumber.from("18910541408996344243"),
-  /* lusdGain */ BigNumber.from("66201062534511228032281"),
-];
-
-const expectedSystemState = [
-  /* borrowFee */ BigNumber.from("6900285109012952"),
-  /* ethTvl */ BigNumber.from("852500462432421494350957"),
-  /* tcr */ BigNumber.from("3250195441371082828"),
-  /* isInRecoveryMode */ false,
-];
+const expectedTrovePosition = {
+  collateral: BigNumber.from("582880000000000000000000"),
+  debt: BigNumber.from("372000200000000000000000000"),
+  icr: BigNumber.from("3859882210893925325"),
+};
+const expectedStabilityPosition = {
+  deposit: BigNumber.from("299979329615565997640451998"),
+  ethGain: BigNumber.from("8629038660000000000"),
+  lqtyGain: BigNumber.from("53244322633874479119945"),
+};
+const expectedStakePosition = {
+  amount: BigNumber.from("981562996504090969804965"),
+  ethGain: BigNumber.from("18910541408996344243"),
+  lusdGain: BigNumber.from("66201062534511228032281"),
+};
+const expectedSystemState = {
+  borrowFee: BigNumber.from("6900285109012952"),
+  ethTvl: BigNumber.from("852500462432421494350957"),
+  tcr: BigNumber.from("3250195441371082828"),
+  isInRecoveryMode: false,
+};
+const expectedTrovePositionHints = {
+  upperHint: "0xbf9a4eCC4151f28C03100bA2C0555a3D3e439e69",
+  lowerHint: "0xa4FC81A7AB93360543eb1e814D0127f466012CED",
+};
+const expectedRedemptionPositionHints = {
+  partialRedemptionHintNicr: "69529933762909647",
+  firstHint: "0xc16aDd8bA17ab81B27e930Da8a67848120565d8c",
+  upperHint: "0x66882C005188F0F4d95825ED7A7F78ed3055f167",
+  lowerHint: "0x0C22C11a8ed4C23ffD19629283548B1692b58e92",
+};
 /* End: Mock test data */
 
 describe("InstaLiquityResolver", () => {
@@ -55,6 +65,7 @@ describe("InstaLiquityResolver", () => {
     );
 
     liquity = await liquityFactory.deploy();
+
     await liquity.deployed();
   });
 
@@ -69,7 +80,11 @@ describe("InstaLiquityResolver", () => {
         JUSTIN_SUN_ADDRESS,
         oracleEthPrice
       );
-      expect(trovePosition).to.eql(expectedTrovePosition);
+      expect(trovePosition.collateral).to.equal(
+        expectedTrovePosition.collateral
+      );
+      expect(trovePosition.debt).to.equal(expectedTrovePosition.debt);
+      expect(trovePosition.icr).to.equal(expectedTrovePosition.icr);
     });
   });
 
@@ -78,14 +93,24 @@ describe("InstaLiquityResolver", () => {
       const stabilityPosition = await liquity.getStabilityDeposit(
         JUSTIN_SUN_ADDRESS
       );
-      expect(stabilityPosition).to.eql(expectedStabilityPosition);
+      expect(stabilityPosition.deposit).to.equal(
+        expectedStabilityPosition.deposit
+      );
+      expect(stabilityPosition.ethGain).to.equal(
+        expectedStabilityPosition.ethGain
+      );
+      expect(stabilityPosition.lqtyGain).to.equal(
+        expectedStabilityPosition.lqtyGain
+      );
     });
   });
 
   describe("getStake()", () => {
     it("returns a user's Stake position", async () => {
       const stakePosition = await liquity.getStake(JUSTIN_SUN_ADDRESS);
-      expect(stakePosition).to.eql(expectedStakePosition);
+      expect(stakePosition.amount).to.equal(expectedStakePosition.amount);
+      expect(stakePosition.ethGain).to.equal(expectedStakePosition.ethGain);
+      expect(stakePosition.lusdGain).to.equal(expectedStakePosition.lusdGain);
     });
   });
 
@@ -96,12 +121,30 @@ describe("InstaLiquityResolver", () => {
         JUSTIN_SUN_ADDRESS,
         oracleEthPrice
       );
-      const expectedPosition = [
-        expectedTrovePosition,
-        expectedStabilityPosition,
-        expectedStakePosition,
-      ];
-      expect(position).to.eql(expectedPosition);
+      const expectedPosition = {
+        trove: expectedTrovePosition,
+        stability: expectedStabilityPosition,
+        stake: expectedStakePosition,
+      };
+      expect(position.trove.collateral).to.equal(
+        expectedPosition.trove.collateral
+      );
+      expect(position.trove.debt).to.equal(expectedPosition.trove.debt);
+      expect(position.trove.icr).to.equal(expectedPosition.trove.icr);
+
+      expect(position.stability.deposit).to.equal(
+        expectedPosition.stability.deposit
+      );
+      expect(position.stability.ethGain).to.equal(
+        expectedPosition.stability.ethGain
+      );
+      expect(position.stability.lqtyGain).to.equal(
+        expectedPosition.stability.lqtyGain
+      );
+
+      expect(position.stake.amount).to.equal(expectedPosition.stake.amount);
+      expect(position.stake.ethGain).to.equal(expectedPosition.stake.ethGain);
+      expect(position.stake.lusdGain).to.equal(expectedPosition.stake.lusdGain);
     });
   });
 
@@ -109,7 +152,12 @@ describe("InstaLiquityResolver", () => {
     it("returns Liquity system state", async () => {
       const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
       const systemState = await liquity.getSystemState(oracleEthPrice);
-      expect(systemState).to.eql(expectedSystemState);
+      expect(systemState.borrowFee).to.equal(expectedSystemState.borrowFee);
+      expect(systemState.ethTvl).to.equal(expectedSystemState.ethTvl);
+      expect(systemState.tcr).to.equal(expectedSystemState.tcr);
+      expect(systemState.isInRecoveryMode).to.equal(
+        expectedSystemState.isInRecoveryMode
+      );
     });
   });
 
@@ -124,8 +172,8 @@ describe("InstaLiquityResolver", () => {
         searchIterations
       );
 
-      expect(upperHint).eq("0xbf9a4eCC4151f28C03100bA2C0555a3D3e439e69");
-      expect(lowerHint).eq("0xa4FC81A7AB93360543eb1e814D0127f466012CED");
+      expect(upperHint).eq(expectedTrovePositionHints.upperHint);
+      expect(lowerHint).eq(expectedTrovePositionHints.lowerHint);
     });
   });
 
@@ -145,10 +193,12 @@ describe("InstaLiquityResolver", () => {
         searchIterations
       );
 
-      expect(partialRedemptionHintNicr).eq("69529933762909647");
-      expect(firstHint).eq("0xc16aDd8bA17ab81B27e930Da8a67848120565d8c");
-      expect(upperHint).eq("0x66882C005188F0F4d95825ED7A7F78ed3055f167");
-      expect(lowerHint).eq("0x0C22C11a8ed4C23ffD19629283548B1692b58e92");
+      expect(partialRedemptionHintNicr).eq(
+        expectedRedemptionPositionHints.partialRedemptionHintNicr
+      );
+      expect(firstHint).eq(expectedRedemptionPositionHints.firstHint);
+      expect(upperHint).eq(expectedRedemptionPositionHints.upperHint);
+      expect(lowerHint).eq(expectedRedemptionPositionHints.lowerHint);
     });
   });
 });

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -24,6 +24,13 @@ const expectedStakePosition = [
   /* ethGain */ BigNumber.from("18910541408996344243"),
   /* lusdGain */ BigNumber.from("66201062534511228032281"),
 ];
+
+const expectedSystemState = [
+  /* borrowFee */ BigNumber.from("6900285109012952"),
+  /* ethTvl */ BigNumber.from("852500462432421494350957"),
+  /* tcr */ BigNumber.from("3232993993257432140"),
+  /* isInRecoveryMode */ false,
+];
 /* End: Mock test data */
 
 describe("InstaLiquityResolver", () => {
@@ -76,6 +83,13 @@ describe("InstaLiquityResolver", () => {
         expectedStakePosition,
       ];
       expect(position).to.eql(expectedPosition);
+    });
+  });
+
+  describe("getSystemState()", () => {
+    it("returns Liquity system state", async () => {
+      const systemState = await liquity.getSystemState();
+      expect(systemState).to.eql(expectedSystemState);
     });
   });
 });

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -164,12 +164,14 @@ describe("InstaLiquityResolver", () => {
   describe("getTrovePositionHints()", () => {
     it("returns the upper and lower address of Troves nearest to the given Trove", async () => {
       const collateral = hre.ethers.utils.parseEther("10");
-      const debt = hre.ethers.utils.parseUnits("5000", 18);
+      const debt = hre.ethers.utils.parseUnits("5000", 18); // 5,000 LUSD
       const searchIterations = 10;
+      const randomSeed = 3;
       const [upperHint, lowerHint] = await liquity.getTrovePositionHints(
         collateral,
         debt,
-        searchIterations
+        searchIterations,
+        randomSeed
       );
 
       expect(upperHint).eq(expectedTrovePositionHints.upperHint);
@@ -182,6 +184,7 @@ describe("InstaLiquityResolver", () => {
       const amount = hre.ethers.utils.parseUnits("10000", 18); // 10,000 LUSD
       const oracleEthPrice = await liquityPriceOracle.callStatic.fetchPrice();
       const searchIterations = 10;
+      const randomSeed = 3;
       const [
         partialRedemptionHintNicr,
         firstHint,
@@ -190,7 +193,8 @@ describe("InstaLiquityResolver", () => {
       ] = await liquity.getRedemptionPositionHints(
         amount,
         oracleEthPrice,
-        searchIterations
+        searchIterations,
+        randomSeed
       );
 
       expect(partialRedemptionHintNicr).eq(


### PR DESCRIPTION
Protocol: https://www.liquity.org/
Docs: https://docs.liquity.org/

This resolvers adds support for reading Liquity protocol state.

There are 7 public readers:

- Trove position data: `collateral, debt, ICR`
- Stability deposit position data: `deposit, ethGain, lqtyGain`
- Stake position data: `amount, ethGain, lusdGain`
- Overall position data: `Trove, StabilityDeposit, Stake`
- Overall system state: `borrowFee, ethTvl, TCR, isInRecoveryMode`
- Trove list position hints for Trove management: `upperHint, lowerHint`
- Trove list position hints for Redemption: `partialHintNicr, firstHint, upperHint, lowerHint`